### PR TITLE
feat: add recursive vault secret collection for nested models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-04-21
+
+### Added
+- add recursive vault secret collection for nested models
+
 ## [2.1.0] - 2024-04-12
 Thank you, @vladimir-kotikov, for your contribution! Support for the new authorization
 method JWT/OIDC was inspired by your MR to the original project.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-settings-vault"
-version = "2.1.1"
+version = "2.2.0"
 description = "A simple extension to pydantic-settings that can retrieve secrets from Hashicorp Vault"
 authors = [
   { name = "Aleksey Petrunnik", email = "petrunnik.a@gmail.com" },
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Security",
 ]
 dependencies = [
-  "pydantic>=2.1.1,<3",
+  "pydantic>=2.2.0,<3",
   "pydantic-settings>=2.0.2,<3",
   "hvac>=0.10.6",
 ]

--- a/src/pydantic_vault/__init__.py
+++ b/src/pydantic_vault/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 from .entities import SettingsConfigDict
 from .vault_settings import VaultParameterError, VaultSettingsSource

--- a/src/pydantic_vault/vault_settings.py
+++ b/src/pydantic_vault/vault_settings.py
@@ -5,7 +5,7 @@ import logging
 import os
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, cast, get_args, get_origin
 
 from hvac import Client as HvacClient
 from hvac.exceptions import VaultError
@@ -310,8 +310,6 @@ class VaultSettingsSource(PydanticBaseSettingsSource):
         raise NotImplementedError  # pragma: no cover
 
     def __call__(self) -> dict[str, Any]:
-        data: dict[str, Any] = {}
-
         vault_client = _get_authenticated_vault_client(
             cast(SettingsConfigDict, self.settings_cls.model_config)
         )
@@ -319,34 +317,7 @@ class VaultSettingsSource(PydanticBaseSettingsSource):
             logger.warning("Could not find a suitable authentication method for Vault")
             return {}
 
-        # Get secrets
-        for field_name, field_info in self.settings_cls.model_fields.items():
-            extra = self._get_field_extra(field_info)
-            vault_secret_path: str | None = extra.get("vault_secret_path")
-            vault_secret_key: str | None = extra.get("vault_secret_key")
-
-            if vault_secret_path is None:
-                logger.debug(f"Skipping field {field_name}")
-                continue
-
-            try:
-                vault_val: str | dict[str, Any] = self._get_vault_secret(
-                    vault_client=vault_client,
-                    vault_secret_path=vault_secret_path,
-                    vault_secret_key=vault_secret_key,
-                )
-            except _ContinueException:
-                continue
-
-            vault_val = self._deserialize_complex_type(
-                vault_val=vault_val,
-                field_info=field_info,
-                vault_secret_path=vault_secret_path,
-                vault_secret_key=vault_secret_key,
-            )
-            data[field_info.alias or field_name] = vault_val
-
-        return data
+        return self._collect_model_secrets(self.settings_cls, vault_client)
 
     def _get_vault_secret(
         self,
@@ -420,3 +391,88 @@ class VaultSettingsSource(PydanticBaseSettingsSource):
         elif callable(field_info.json_schema_extra):
             field_info.json_schema_extra(extra)
         return extra
+
+    def _collect_model_secrets(
+        self, model_cls: type[BaseSettings] | type[Any], vault_client: HvacClient
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        model_fields = getattr(model_cls, "model_fields", {})
+        for field_name, field_info in model_fields.items():
+            field_value = self._resolve_field_value(field_name, field_info, vault_client)
+            if field_value is _MISSING:
+                continue
+            data[field_info.alias or field_name] = field_value
+        return data
+
+    def _resolve_field_value(
+        self, field_name: str, field_info: FieldInfo, vault_client: HvacClient
+    ) -> Any:
+        current_value: Any = _MISSING
+        extra = self._get_field_extra(field_info)
+        vault_secret_path: str | None = extra.get("vault_secret_path")
+        vault_secret_key: str | None = extra.get("vault_secret_key")
+
+        if vault_secret_path is not None:
+            try:
+                vault_val: str | dict[str, Any] = self._get_vault_secret(
+                    vault_client=vault_client,
+                    vault_secret_path=vault_secret_path,
+                    vault_secret_key=vault_secret_key,
+                )
+            except _ContinueException:
+                vault_val = _MISSING
+
+            if vault_val is not _MISSING:
+                current_value = self._deserialize_complex_type(
+                    vault_val=vault_val,
+                    field_info=field_info,
+                    vault_secret_path=vault_secret_path,
+                    vault_secret_key=vault_secret_key,
+                )
+
+        nested_model = self._extract_nested_model(field_info.annotation)
+        if nested_model is None:
+            if current_value is _MISSING:
+                logger.debug(f"Skipping field {field_name}")
+            return current_value
+
+        nested_data = self._collect_model_secrets(nested_model, vault_client)
+        if not nested_data:
+            return current_value
+
+        if current_value is _MISSING:
+            return nested_data
+        if isinstance(current_value, dict):
+            return self._deep_merge_dict(current_value, nested_data)
+        return current_value
+
+    def _extract_nested_model(self, annotation: Any) -> type[Any] | None:
+        if annotation is None:
+            return None
+        if hasattr(annotation, "model_fields"):
+            return cast("type[Any]", annotation)
+
+        origin = get_origin(annotation)
+        if origin is None:
+            return None
+
+        for arg in get_args(annotation):
+            if arg is type(None):
+                continue
+            nested_model = self._extract_nested_model(arg)
+            if nested_model is not None:
+                return nested_model
+        return None
+
+    def _deep_merge_dict(self, primary: dict[str, Any], fallback: dict[str, Any]) -> dict[str, Any]:
+        merged = dict(primary)
+        for key, fallback_value in fallback.items():
+            current_value = merged.get(key)
+            if isinstance(current_value, dict) and isinstance(fallback_value, dict):
+                merged[key] = self._deep_merge_dict(current_value, fallback_value)
+            elif key not in merged:
+                merged[key] = fallback_value
+        return merged
+
+
+_MISSING = object()

--- a/tests/test_settings_source.py
+++ b/tests/test_settings_source.py
@@ -219,6 +219,49 @@ def test_get_secret_without_key() -> None:
     }
 
 
+def test_get_secrets_recursively_for_nested_models() -> None:
+    class ServiceCredentials(BaseModel):
+        username: str = Field(
+            "doesn't matter",
+            json_schema_extra={
+                "vault_secret_path": "secret/data/first_level_key",
+                "vault_secret_key": "username",
+            },
+        )
+        password: SecretStr = Field(  # type: ignore
+            "doesn't matter",
+            json_schema_extra={
+                "vault_secret_path": "secret/data/first_level_key",
+                "vault_secret_key": "password",
+            },
+        )
+
+    class Services(BaseModel):
+        primary: ServiceCredentials
+        secondary: ServiceCredentials
+
+    class Platform(BaseModel):
+        services: Services
+
+    class Settings(BaseSettings):
+        platform: Platform
+
+        model_config: ClassVar[SettingsConfigDict] = {
+            "vault_url": "https://vault.tld",
+            "vault_token": SecretStr("fake-token"),
+        }
+
+    vault_settings_dict = VaultSettingsSource(Settings)()
+    assert vault_settings_dict == {
+        "platform": {
+            "services": {
+                "primary": {"username": "kvv2_user", "password": "kvv2_password"},
+                "secondary": {"username": "kvv2_user", "password": "kvv2_password"},
+            }
+        }
+    }
+
+
 def test_get_secrets_from_different_mount_points() -> None:
     class Settings(BaseSettings):
         field_from_kvv1: str = Field(


### PR DESCRIPTION
Hi @aleksey925,

Thanks for your work on this library before anything

I wanted to use it for fetching secrets from vault but noticed that if we nest pydantic models within an other and specify the vault secret path in nested models, it doesn't work, the secrets are populated only for the top level Settings class, for the fields with the vault secret path specified.

This PR allows to traverse all the pydantic models and populates the lower level ones if the vault secret path is specified for them, that's quite useful for my use case and thought this could be merged here, especially as there is no regression identified by the tests.

(ai generated from here, but perfectly describes the PR)
## Summary

- Add recursive secret collection in `VaultSettingsSource` so nested `BaseModel`/`BaseSettings` fields are traversed and hydrated from Vault when their fields define `vault_secret_path` metadata.
- Keep existing behavior for top-level fields and add merge logic so explicit parent values are preserved while nested fallback values are filled in.
- Add a regression test covering multi-level nested models with repeated credential submodels.

## Why

Nested settings structures are common, but Vault resolution previously only inspected top-level fields of the settings class. This made deeply nested `json_schema_extra` Vault metadata ineffective unless flattened manually.

This change enables nested secret injection without forcing users to redesign their settings hierarchy.

## Implementation details

- Refactor `VaultSettingsSource.__call__` to delegate to recursive traversal.
- Add `_collect_model_secrets()` to iterate model fields and gather values.
- Add `_resolve_field_value()` to:
  - load current field from Vault when field-level metadata is present,
  - detect nested model annotations,
  - recursively collect nested data,
  - deep-merge nested fallback values when both top-level and nested dict data exist.
- Add `_extract_nested_model()` to unwrap direct and union-like annotations (e.g. optional nested models).
- Add `_deep_merge_dict()` for deterministic non-destructive merge behavior.
- Add `_MISSING` sentinel to differentiate "not found" from legitimate falsey values.

## Test plan

- [x] `uv run pytest -q`
- [x] Added nested recursion test in `tests/test_settings_source.py`

### Test output

```text
$ uv run pytest -q
....................................................                     [100%]
52 passed in 2.06s
```

## Affected files

- `src/pydantic_vault/vault_settings.py`
- `tests/test_settings_source.py`
